### PR TITLE
Update configuration script with better permissions behavior

### DIFF
--- a/root/etc/cont-init.d/30-config
+++ b/root/etc/cont-init.d/30-config
@@ -1,21 +1,25 @@
 #!/usr/bin/with-contenv bash
 
-# make our folders
+# make our folders
 mkdir -p \
-	/var/cache/ddclient \
-	/var/run/ddclient
+        /var/cache/ddclient \
+        /var/run/ddclient
 
 # copy default config if not present in /config
 [[ ! -e /config/ddclient.conf ]] && \
-	cp /defaults/ddclient.conf /config
+        cp /defaults/ddclient.conf /config
 
 # copy config from /config to root
 cp /config/ddclient.conf /ddclient.conf
 
-# permissions
+# permissions
 chown -R abc:abc \
-	/config \
-	/var/cache/ddclient \
-	/var/run/ddclient
-chmod -R 600 \
-	/config
+        /config \
+        /var/cache/ddclient \
+        /var/run/ddclient \
+        /ddclient.conf
+
+chmod 700 /config
+chmod 600 \
+	/config/* \
+	/ddclient.conf


### PR DESCRIPTION
fixes #30

Updated the permission setting script to:
- chmod/chown the eventual config file that gets run, killing a warning that kept appearing in the logs
- chmod the config directory with +x, so it remains accessible
- chmod config files to 600